### PR TITLE
[refactor/#17]:마이페이지 탭메뉴 객체배열로 변환

### DIFF
--- a/app/mypage/layout.module.css
+++ b/app/mypage/layout.module.css
@@ -1,1 +1,1 @@
-.container_inner{border-radius: 6px; background-color: #fff; text-align: center;}
+.inner{border-radius: 6px; background-color: #fff;}

--- a/app/mypage/layout.tsx
+++ b/app/mypage/layout.tsx
@@ -5,10 +5,14 @@ import styles from './layout.module.css';
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <Container size="2" p="6">
-      <Box p="4" pt="9" className={styles.container_inner}>
+      <Box p="4" pt="9" className={styles.inner}>
         {/* 마이페이지 공통 프로필 영역 */}
         <UserProfile />
-        {children}
+      </Box>
+      <Box mt="3" p="4" className={`${styles.inner} ${styles.content}`} asChild>
+        <section>
+          {children}
+        </section>
       </Box>
     </Container>
   );

--- a/app/mypage/layout.tsx
+++ b/app/mypage/layout.tsx
@@ -1,15 +1,15 @@
-import UserProfile from "@/components/mypage/UserProfile";
-import { Box, Container } from "@radix-ui/themes";
+import UserProfile from '@/components/mypage/UserProfile';
+import { Box, Container } from '@radix-ui/themes';
 import styles from './layout.module.css';
 
-export default function Layout({children}: {children: React.ReactNode}) {
-    return (
-        <Container size="2" p="6">
-            <Box p="4" pt="9" className={styles.container_inner}>
-                {/* 마이페이지 공통 프로필 영역 */}
-                <UserProfile />
-                {children}
-            </Box>
-        </Container>
-    );
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <Container size="2" p="6">
+      <Box p="4" pt="9" className={styles.container_inner}>
+        {/* 마이페이지 공통 프로필 영역 */}
+        <UserProfile />
+        {children}
+      </Box>
+    </Container>
+  );
 }

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,6 +1,6 @@
 import { Container } from "@radix-ui/themes";
-
 export default function Mypage() {
+  
   return (
     <Container size='2'>
 

--- a/app/mypage/pwupdate/page.tsx
+++ b/app/mypage/pwupdate/page.tsx
@@ -1,5 +1,5 @@
 export default function PwUpdate() {
   return (
-    <div></div>
+    <div>비밀번호 수정</div>
   );
 }

--- a/app/mypage/pwupdate/page.tsx
+++ b/app/mypage/pwupdate/page.tsx
@@ -1,5 +1,32 @@
+import ButtonSubmit from "@/components/common/ButtonSubmit";
+import { Box, Text } from "@radix-ui/themes";
+
 export default function PwUpdate() {
   return (
-    <div>비밀번호 수정</div>
+    <>
+      <Box className="form_box">
+        <form action="">
+          <Box className="row">
+            <Text as="label" weight="medium">현재 비밀번호</Text>
+            <Box mt="2">
+              <input type="password" placeholder="현재 비밀번호를 입력해주세요." />
+            </Box>
+          </Box>
+          <Box mt="3" className="row">
+            <Text as="label" weight="medium">새 비밀번호</Text>
+            <Box mt="2">
+              <input type="password" placeholder="새로운 비밀번호를 입력해주세요." />
+            </Box>
+          </Box>
+          <Box mt="3" className="row">
+            <Text as="label" weight="medium">새 비밀번호 확인</Text>
+            <Box mt="2">
+              <input type="password" placeholder="새 비밀번호를 다시 한 번 입력해주세요." />
+            </Box>
+          </Box>
+          <ButtonSubmit />
+        </form>
+      </Box>
+    </>
   );
 }

--- a/app/mypage/subjectedit/page.tsx
+++ b/app/mypage/subjectedit/page.tsx
@@ -1,3 +1,3 @@
 export default function SubjectEdit() {
-  return <div></div>;
+  return <div>과목편집</div>;
 }

--- a/app/reset.css
+++ b/app/reset.css
@@ -35,6 +35,7 @@ input,
 select,
 textarea,
 button {
+  font-family: var(--font-notosanskr) !important;
   line-height: 1.5;
   color: #333;
   word-break: keep-all;
@@ -113,7 +114,7 @@ q:after {
 
 input,
 textarea {
-  padding: 0 25px;
+  padding: 0 20px;
 }
 
 input:-webkit-autofill {
@@ -133,6 +134,36 @@ input[type='submit'],
 input[type='search'],
 input[type='number'] {
   -webkit-appearance: none;
+}
+
+input[type="text"],
+input[type="password"],
+input[type="tel"],
+input[type="email"],
+input[type="number"],
+input[type="url"]{
+  text-overflow:ellipsis; 
+  overflow:hidden; 
+  display: -webkit-box; 
+  -webkit-box-orient: vertical; 
+  -webkit-line-clamp: 1;
+}
+
+input[type='text'],
+input[type='password']{
+  display: block;
+  width: 100%;
+  height: 60px;
+  line-height: 58px;
+  border-radius: 6px;
+  border: 1px solid var(--br-color);
+  box-sizing: border-box;
+}
+
+input[type='text']::placeholder,
+input[type='password']::placeholder{
+  font-size: 14px;
+  color: #999;
 }
 
 input[type='number']::-webkit-outer-spin-button,

--- a/components/common/ButtonSubmit.module.css
+++ b/components/common/ButtonSubmit.module.css
@@ -1,0 +1,1 @@
+.btn_submit button{display: block; width:100%; height: 60px; border-radius: 6px; background-color: var(--main-color-3); font-size: 16px; font-weight: 500; color: #fff;}

--- a/components/common/ButtonSubmit.tsx
+++ b/components/common/ButtonSubmit.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { Box } from '@radix-ui/themes';
+import styles from './ButtonSubmit.module.css';
+
+export default function ButtonSubmit() {
+    return (
+        <Box mt="6" className={styles.btn_submit}>
+            <button type="submit" >저장</button>
+        </Box>
+    );
+}

--- a/components/mypage/MypageTabMenu.tsx
+++ b/components/mypage/MypageTabMenu.tsx
@@ -1,32 +1,58 @@
 'use client';
 
-import Link from "next/link";
+import Link from 'next/link';
 import styles from './MypageTabMenu.module.css';
-import { Box, ChevronDownIcon } from "@radix-ui/themes";
-import { useState } from "react";
+import { Box, ChevronDownIcon } from '@radix-ui/themes';
+import { useState } from 'react';
+import { usePathname } from 'next/navigation';
 
 export default function MypageTabMenu() {
+  // 탭을 열고닫는 boolean
   const [openTab, setOpenTab] = useState(false);
+
+  // path
+  const pathname = usePathname();
+
+  // 탭메뉴 배열
+  const tabMenu = [
+    { link: '/mypage', title: '내 배지 조회' },
+    { link: '/mypage/subjectedit', title: '과목 편집' },
+    { link: '/mypage/pwupdate', title: '비밀번호 수정' },
+  ];
+
+  const [pathTabTitle] = tabMenu.filter((tab)=>{return tab.link == pathname});
+
   return (
     <Box mt="6" className={styles.tab_menu}>
-      <a href="#" onClick={(e)=>{e.preventDefault(); setOpenTab(!openTab);}}>
-        내 배지 조회
+      <a
+        href="#"
+        onClick={(e) => {
+          e.preventDefault();
+          setOpenTab(!openTab);
+        }}
+      >
+        {pathTabTitle.title}
         <ChevronDownIcon />
       </a>
-      {
-        openTab &&
+      {openTab && (
         <ul>
-          <li>
-            <Link href="">내 배지 조회</Link>
-          </li>
-          <li>
-            <Link href="">과목 편집</Link>
-          </li>
-          <li>
-            <Link href="">비밀번호 수정</Link>
-          </li>
+          {tabMenu.map((tab) => {
+            return (
+              <li>
+                <Link href={tab.link} legacyBehavior>
+                  <a
+                    onClick={() => {
+                      setOpenTab(false);
+                    }}
+                  >
+                    {tab.title}
+                  </a>
+                </Link>
+              </li>
+            );
+          })}
         </ul>
-      }
+      )}
     </Box>
   );
 }

--- a/components/mypage/UserProfile.module.css
+++ b/components/mypage/UserProfile.module.css
@@ -1,4 +1,4 @@
-.user_infO{font-size: 0;}
+.user_info{font-size: 0; text-align: center;}
 .img_box {position: relative; display: inline-block;}
 .back_img {background-repeat: no-repeat; background-position: 50% 50%; border-radius: 100%; background-size: cover; overflow: hidden;}
 .back_img span{width: 180px; height: 180px;}


### PR DESCRIPTION
## 📋 연관된 이슈 번호
- #17 

## 📚 변경 사항
- 탭메뉴를 객체배열로 만들어서 반복문으로 돌림
- 겹치는 코드 삭제
- 페이지 이동시 탭메뉴 닫힘
- 페이지 이동시 자동으로 탭메뉴 텍스트 바뀜 
