### PR TITLE
[feat/#17]:마이페이지 과목편집 컴포넌트 적용

### DIFF
--- a/app/mypage/subjectedit/page.tsx
+++ b/app/mypage/subjectedit/page.tsx
@@ -1,3 +1,36 @@
-export default function SubjectEdit() {
-  return <div>과목편집</div>;
+'use client';
+
+import SubjectEdit from '@/components/study/SubjectEdit';
+import { useState } from 'react';
+
+const initialSubjects: string[] = ['html', 'css', 'javascript'];
+
+interface SubjectEditFormProps {
+  closeSubjectEditForm: () => void;
+}
+
+export default function Page() {
+  const [subjects, setSubjects] = useState<string[]>(initialSubjects);
+  const [selectedSubjects, setSelectedSubjects] = useState<string[]>([]);
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+  const [deletedSubjects, setDeletedSubjects] = useState<string[]>([]);
+
+  const handleAddSubject = (subject: string) => {
+    setSubjects([...subjects, subject]);
+  };
+
+  const handleDeleteSubject = (subjectToDelete: string) => {
+    setSubjects(subjects.filter((subject) => subject !== subjectToDelete));
+    setSelectedSubjects((prevSelected) => prevSelected.filter((s) => s !== subjectToDelete));
+    setDeletedSubjects((prevDeleted) => [...prevDeleted, subjectToDelete]);
+  };
+
+  return (
+    <SubjectEdit
+      subjects={subjects}
+      onAddSubject={handleAddSubject}
+      onDeleteSubject={handleDeleteSubject}
+      onCancelEditing={() => setIsEditing(false)}
+    />
+  );
 }


### PR DESCRIPTION
## 📋 연관된 이슈 번호
- #17 

## 🛠 구현 사항
- 과목편집 컴포넌트 마이페이지 해당 탭에 적용

## 📚 변경 사항
-  SubjectEdit가 이름이 겹쳐서 Page.tsx로 변경

## 🏜 스크린샷
![image](https://github.com/user-attachments/assets/ed43a445-8de5-4ef6-9dc7-3e59355e3e5b)
![image](https://github.com/user-attachments/assets/c21b6766-0119-49b1-b035-63c9413e4de6)
