### PR TITLE
[style/#31]:모바일 메뉴 스타일 수정

### DIFF
--- a/components/common/Header/MobileHeader.module.css
+++ b/components/common/Header/MobileHeader.module.css
@@ -1,4 +1,4 @@
-.footer{display:none !important; position:fixed; left:0; bottom:0; width:100%; height: 60px; background-color: #fff; border-radius: 8px 8px 0 0; box-shadow: var(--shadow-3);}
+.footer{display:none !important; position:fixed; left:0; bottom:0; width:100%; height: 60px; background-color: #fff; border-radius: 8px 8px 0 0; box-shadow: var(--shadow-3); z-index: 100;}
 .footer ul{height: 100%;}
 .footer ul li{width: 25%; text-align: center;}
 .footer ul li .svg{font-size: 0;}

--- a/components/common/Header/MobileHeader.tsx
+++ b/components/common/Header/MobileHeader.tsx
@@ -32,7 +32,7 @@ export default function MobileHeader() {
                     />
                   </svg>
                 </div>
-                <Text as="p" size="2" weight="medium" mt="1">
+                <Text as="p" size="2" weight="medium" mt="2">
                   공부하기
                 </Text>
               </Link>
@@ -54,7 +54,7 @@ export default function MobileHeader() {
                     />
                   </svg>
                 </div>
-                <Text as="p" size="2" weight="medium" mt="1">
+                <Text as="p" size="2" weight="medium" mt="2">
                   순위확인
                 </Text>
               </Link>
@@ -98,7 +98,7 @@ export default function MobileHeader() {
                     />
                   </svg>
                 </div>
-                <Text as="p" size="2" weight="medium" mt="1">
+                <Text as="p" size="2" weight="medium" mt="2">
                   기록확인
                 </Text>
               </Link>
@@ -118,7 +118,7 @@ export default function MobileHeader() {
                     />
                   </svg>
                 </div>
-                <Text as="p" size="2" weight="medium" mt="1">
+                <Text as="p" size="2" weight="medium" mt="2">
                   마이페이지
                 </Text>
               </Link>


### PR DESCRIPTION
## 📋 연관된 이슈 번호
- #31

## 📚 변경 사항
- 모바일 메뉴 하단 간격 mt=1에서 mt=2로 조절
- 모바일 메뉴 z-index 값 100으로 수정

## 🏜 스크린샷
![image](https://github.com/user-attachments/assets/85d628b7-a9a9-45d0-a525-a7789e52f076)
- 변경전
![image](https://github.com/user-attachments/assets/334acfb1-e4b9-484e-8e5d-c3fb9b9e58cb)
- 변경후
![image](https://github.com/user-attachments/assets/572ad53b-0fd4-4edd-823a-513f5753b786)
