### PR TITLE
[style/#64]: 랭킹 레이아웃 수정

### DIFF
--- a/app/ranking/page.tsx
+++ b/app/ranking/page.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import TopRankings from '@/components/ranking/topLanking';
 import FullRankingList from '@/components/ranking/fullRankingList';
-import { Grid } from '@radix-ui/themes';
+import { Box, Flex, Grid } from '@radix-ui/themes';
 import styles from './ranking.module.css';
 import rankingImg from '@/assets/icons/ranking_profile_img.png';
 import { fetchRankingsAndCurrentUserFromServer } from '@/api/rankingApi';
@@ -62,10 +62,10 @@ export default function Ranking() {
           pageNumber: nextPage,
           size,
         });
-  
+
         console.log('API Response:', response); // 추가된 로그
         const newRankings = response.ranking.ranks; // API 응답에서 랭킹 데이터 추출
-  
+
         setRankings((prevRankings) => [...prevRankings, ...newRankings]);
         setHasMore(response.ranking.hasNext);
         setPage(nextPage);
@@ -74,44 +74,55 @@ export default function Ranking() {
       }
     }
   }, [activeTab, hasMore, page]);
-  
 
   return (
-    <Grid columns="1" gap="2" rows="repeat(1, 100px)" className={styles.ranking_wrap}>
-      <Grid columns="1" gap="3" rows="repeat(1, 64px)" className={styles.ranking_wrap_inner}>
-        <Grid columns="3" gap="1" rows="repeat(1, 64px)" className={styles.date_tap_wrap}>
-          <button
-            className={`${styles.date_tap_btn} ${activeTab === 'DAILY' ? styles.date_tap_btn_active : ''}`}
-            onClick={() => setActiveTab('DAILY')}
-          >
-            일간
-          </button>
-          <button
-            className={`${styles.date_tap_btn} ${activeTab === 'WEEKLY' ? styles.date_tap_btn_active : ''}`}
-            onClick={() => setActiveTab('WEEKLY')}
-          >
-            주간
-          </button>
-          <button
-            className={`${styles.date_tap_btn} ${activeTab === 'MONTHLY' ? styles.date_tap_btn_active : ''}`}
-            onClick={() => setActiveTab('MONTHLY')}
-          >
-            월간
-          </button>
-        </Grid>
-        <Grid className={styles.top_rankings_wrap}>
-          <TopRankings rankings={rankings} activeTab={activeTab} />
-        </Grid>
-      </Grid>
-      <Grid className={styles.full_ranking_wrap}>
-        <FullRankingList
-          rankings={rankings}
-          currentUser={currentUser}
-          activeTab={activeTab}
-          loadMore={loadMore}
-          hasMore={hasMore}
-        />
-      </Grid>
-    </Grid>
+    <section className={styles.container}>
+      <Flex direction="column" justify="between" className={styles.container_inner}>
+        <Box className="top">
+          <Box py="5" className={styles.tab_category}>
+            <Flex gap="10px" justify="center" asChild>
+              <ul>
+                <li>
+                  <button
+                    className={`${activeTab === 'DAILY' ? styles.active : ''}`}
+                    onClick={() => setActiveTab('DAILY')}
+                  >
+                    일간
+                  </button>
+                </li>
+                <li>
+                  <button
+                    className={`${activeTab === 'WEEKLY' ? styles.active : ''}`}
+                    onClick={() => setActiveTab('WEEKLY')}
+                  >
+                    주간
+                  </button>
+                </li>
+                <li>
+                  <button
+                    className={`${activeTab === 'MONTHLY' ? styles.active : ''}`}
+                    onClick={() => setActiveTab('MONTHLY')}
+                  >
+                    월간
+                  </button>
+                </li>
+              </ul>
+            </Flex>
+          </Box>
+          <Grid className={styles.top_rankings_wrap}>
+            <TopRankings rankings={rankings} activeTab={activeTab} />
+          </Grid>
+        </Box>
+        <Box p="5" pr="3" className={styles.btm}>
+          <FullRankingList
+            rankings={rankings}
+            currentUser={currentUser}
+            activeTab={activeTab}
+            loadMore={loadMore}
+            hasMore={hasMore}
+          />
+        </Box>
+      </Flex>
+    </section>
   );
 }

--- a/app/ranking/ranking.module.css
+++ b/app/ranking/ranking.module.css
@@ -1,6 +1,7 @@
 .container {
   height: 1px;
-  min-height: calc(100vh - 77px);  
+  min-height: calc(100vh - 77px);
+  overflow-y: auto;
 }
 
 .container_inner {

--- a/app/ranking/ranking.module.css
+++ b/app/ranking/ranking.module.css
@@ -1,40 +1,21 @@
-/* ranking.module.css */
-.ranking_wrap {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  background-color: var(--bg-color);
-  text-align: center;
-
+.container {
+  height: 1px;
+  min-height: calc(100vh - 77px);  
 }
 
-.ranking_wrap_inner {
-  width: 90%;
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-  flex-direction: column;
+.container_inner {
+  height: 100%;
 }
 
-.date_tap_wrap {
-  padding: 20px 0px;
-}
-
-.date_tap_btn {
-  background-color: transparent;
+.tab_category button {
+  position: relative;
+  display: block;
   width: 120px;
   height: 50px;
-  border: none;
   font-size: var(--font-size-4);
-  position: relative;
-  /* padding: 40px 5px; */
-  display: inline-block;
-  margin: 0 5px;
 }
 
-.date_tap_btn::after {
+.tab_category button::after {
   content: "";
   position: absolute;
   bottom: 0;
@@ -44,18 +25,18 @@
   border-radius: 5px;
   background-color: var(--main-color-2);
   transition: background-color 0.3s ease, height 0.3s ease;
-  box-shadow: 0 2px 0 0 transparent;
+  /* box-shadow: 0 2px 0 0 transparent; */
 }
 
-.date_tap_btn_active {
+.tab_category button.active {
   font-weight: bold; 
 }
 
-.date_tap_btn_active::after {
+.tab_category button.active::after {
   background-color: var(--main-color-3);
   height: 3.5px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1),
-    0 6px 14px rgba(0, 0, 0, 0.1);
+  /* box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1),
+    0 6px 14px rgba(0, 0, 0, 0.1); */
 }
 
 .top_rankings_wrap {
@@ -65,39 +46,34 @@
   padding: 30px 0px;
 }
 
-.full_ranking_wrap {
-  width: 100%;
+.btm {
+  /* width: 100%;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1),
-    0 8px 16px rgba(0, 0, 0, 0.1);
+  0 8px 16px rgba(0, 0, 0, 0.1); */
+  /* margin-top: 30px;
+  padding-top: 50px; */
+  border-top-left-radius: 30px;
+  border-top-right-radius: 30px;
   background-color: #fff;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  margin-top: 30px;
-  padding-top: 50px;
-  border-top-left-radius: 100px;
-  border-top-right-radius: 100px;
+  border: 1px solid #f1f1ff;
+    
 }
 
+@media screen and (max-width: 860px){
+  .container {
+    min-height: calc(100vh - 62px);  
+  }
+}
 @media screen and (max-width: 680px) {
-  .full_ranking_wrap {
-    border-top-left-radius: 70px;
-    border-top-right-radius: 70px;
+  .container {
+    min-height: calc(100vh - 122px);  
   }
 
-}
-@media (max-width: 480px) {
-  .date_tap_wrap {
-    padding: 20px 0px;
-  }
-
-  .date_tap_btn {
+  .tab_category button {
     width: 90px;
+    height: 40px;
     font-size: var(--font-size-3);
   }
 
-  .top_rankings_wrap {
-    width: auto;
-    padding: 5px 0px;
-  }
+  .btm{padding: 15px; padding-right: 7.5px;}
 }

--- a/components/ranking/fullRankingList.module.css
+++ b/components/ranking/fullRankingList.module.css
@@ -1,153 +1,71 @@
-.full_ranking_container {
-    position: relative;
-    max-height: 500px;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-    width: 90%;
+.scroll_table {
+  position: relative;
+  max-height: 500px;
+  overflow: hidden;
+}
+.scroll_table > div {
+  padding-right: 12px;
 }
 
-.full_ranking_table_wrap {
-    width: 100%;
-    border-collapse: collapse;
-    table-layout: fixed;
+.scroll_table thead th {
+  position: sticky;
+  top: 0;
+  height: 60px;
+  padding: 0 10px;
+  text-align: center;
+  background-color: #f1f1ff;
+  z-index: 1;
 }
 
-.full_ranking_thead_wrap th {
-    position: sticky;
-    top: 0;
-    background-color: #F1F1FF;
-    z-index: 1;
+.scroll_table thead th.name {
+  text-align: left;
 }
 
-.full_ranking_tr>th {
-    height: 50px;
-    background-color: #F1F1FF;
+.scroll_table thead th.radius_left{
+  border-radius: 8px 0 0 8px;
 }
 
-.full_ranking_tr>th:first-child {
-
-    border-radius: 8px 0 0 8px;
+.scroll_table thead th.radius_right {
+  border-radius: 0 8px 8px 0;
 }
 
-.full_ranking_tr>th:last-child {
-    height: 60px;
-    border-radius: 0 8px 8px 0;
+.scroll_table tbody td {
+  height: 50px;
+  padding: 0 10px;
+  text-align: center;
 }
 
-.full_ranking_student {
-    height: 50px;
-
+.scroll_table tbody td.name {
+  text-align: left;
 }
 
-.full_ranking_student img {
-    width: 30px;
-    height: 30px;
-    border-radius: 50%;
+.scroll_table tbody td.blank {
+  height: 0;
+  padding-top: 10px;
 }
 
-.full_ranking_thead_wrap th {
-    padding: 5px 0;
+.scroll_table tbody img {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
 }
 
-.full_ranking_tbody_wrap td {
-    padding: 25px 0;
+.scroll_table {
+  max-height: 400px;
+  overflow-y: auto;
 }
 
-.full_ranking_thead_wrap th:nth-child(1),
-.full_ranking_tbody_wrap td:nth-child(1) {
-    width: 15%;
-}
-
-.full_ranking_thead_wrap th:nth-child(2),
-.full_ranking_tbody_wrap td:nth-child(2) {
-    width: 5%;
-}
-
-.full_ranking_thead_wrap th:nth-child(3),
-.full_ranking_tbody_wrap td:nth-child(3) {
-    width: 8%;
-}
-
-.full_ranking_thead_wrap th:nth-child(4),
-.full_ranking_tbody_wrap td:nth-child(4) {
-    width: 20%;
-}
-
-.full_ranking_thead_wrap th:nth-child(5),
-.full_ranking_tbody_wrap td:nth-child(5) {
-    width: 20%;
-}
-
-.full_ranking_thead_wrap th:nth-child(6),
-.full_ranking_tbody_wrap td:nth-child(6) {
-    width: 15%;
-}
-
-.full_ranking_thead_wrap th:nth-child(7),
-.full_ranking_tbody_wrap td:nth-child(7) {
-    width: 15%;
-}
-
-.scrollable_tbody {
-    max-height: 400px;
-    /* Adjust as needed */
-    overflow-y: auto;
-    /* Enable scrolling */
-}
-
-
+.scroll_table::-webkit-scrollbar {width: 3px;}
+.scroll_table::-webkit-scrollbar-thumb {background: #b9b9b9; border-radius: 3px;}
+.scroll_table::-webkit-scrollbar-track {background: #eee; border-radius: 3px;}
 
 @media screen and (max-width: 680px) {
-    .full_ranking_tr>th {
-        line-height: 1;
-        font-size: var(--font-size-2);
-    }
+  .scroll_table thead th,
+  .scroll_table tbody td {
+    font-size: var(--font-size-2);
+  }
 
-    .full_ranking_student>td {
-        height: 25px;
-        font-size: var(--font-size-2);
-    }
-
-    /* 이미지 */
-    .full_ranking_thead_wrap th:nth-child(2),
-    .full_ranking_tbody_wrap td:nth-child(2) {
-        width: 7%;
-    }
-    
-
-    /* 이름 */
-    .full_ranking_thead_wrap th:nth-child(3),
-    .full_ranking_tbody_wrap td:nth-child(3) {
-        width: 20%;
-    }
-
-    /* 공백 */
-    .full_ranking_thead_wrap th:nth-child(4),
-    .full_ranking_tbody_wrap td:nth-child(4) {
-        width: 10%;
-    }
-
-    .full_ranking_thead_wrap th:nth-child(5),
-    .full_ranking_tbody_wrap td:nth-child(5) {
-        display: none;
-    }
-
-    .full_ranking_thead_wrap th:nth-child(6),
-    .full_ranking_tbody_wrap td:nth-child(6) {
-        width: 20%;
-    }
-
-    .full_ranking_thead_wrap th:nth-child(7),
-    .full_ranking_tbody_wrap td:nth-child(7) {
-        width: 20%;
-    }
-
-
-    .full_ranking_thead_wrap th {
-        padding: 0px 0;
-    }
-
-
+  .scroll_table > div {
+    padding-right: 7.5px;
+  }
 }
-

--- a/components/ranking/fullRankingList.tsx
+++ b/components/ranking/fullRankingList.tsx
@@ -13,7 +13,7 @@ interface FullRankingListProps {
   hasMore: boolean;
 }
 
-function FullRankingList({ rankings, currentUser, activeTab, loadMore, hasMore }: FullRankingListProps) {
+export default function FullRankingList({ rankings, currentUser, activeTab, loadMore, hasMore }: FullRankingListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const otherRankings = rankings.filter((student) => student.id !== currentUser?.id);
@@ -29,61 +29,64 @@ function FullRankingList({ rankings, currentUser, activeTab, loadMore, hasMore }
   };
 
   return (
-    <div className={styles.full_ranking_container}>
-      <table className={styles.full_ranking_table_wrap}>
-        <thead className={styles.full_ranking_thead_wrap}>
-          <tr className={styles.full_ranking_tr}>
-            <th>순위</th>
-            <th></th>
-            <th>이름</th>
-            <th></th>
-            <th>반</th>
-            <th>{timeLabel}</th>
-            <th>누적시간</th>
-          </tr>
-        </thead>
-      </table>
-      <div className={styles.scrollable_tbody}>
-        <InfiniteScroll
-          pageStart={0}
-          loadMore={loadMore}
-          hasMore={hasMore}
-          loader={
-            <div className={styles.loader} key={0}>
-              Loading...
-            </div>
-          }
-          useWindow={false}
-          getScrollParent={() => containerRef.current}
-        >
-          <table className={styles.full_ranking_table_wrap}>
-            <tbody className={styles.full_ranking_tbody_wrap}>
-              {allRankings.map((student) => (
-                <tr key={student.id} className={styles.full_ranking_student}>
-                  <td>{student.rank}</td>
-                  <td>
-                    {student.image && (
-                      <Image src={student.image} alt="Student Image" className={styles.student_image} />
-                    )}
-                  </td>
-                  <td>
-                    {student.name}
-                    {currentUser && student.id === currentUser.id && (
-                      <span className={styles.current_user_label}> (나)</span>
-                    )}
-                  </td>
-                  <td></td>
-                  <td>{student.course}</td>
-                  <td>{formatTime(student.studyTime)}</td>
-                  <td>{formatTime(student.totalTime)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </InfiniteScroll>
-      </div>
+    <div className={styles.scroll_table}>
+      <InfiniteScroll
+        pageStart={0}
+        loadMore={loadMore}
+        hasMore={hasMore}
+        loader={
+          <div className={styles.loader} key={0}>
+            Loading...
+          </div>
+        }
+        useWindow={false}
+        getScrollParent={() => containerRef.current}
+      >
+        <table>
+          <colgroup>
+            <col width="15%" />
+            <col width="50px" />
+            <col width="*" />
+            <col width="20%" />
+            <col width="15%" />
+            <col width="15%" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th className={styles.radius_left}>순위</th>
+              <th></th>
+              <th className={styles.name}>이름</th>
+              <th>반</th>
+              <th>{timeLabel}</th>
+              <th className={styles.radius_right}>누적시간</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td colSpan={6} className={styles.blank}></td>
+            </tr>
+            {allRankings.map((student) => (
+              <tr key={student.id} className={styles.full_ranking_student}>
+                <td>{student.rank}</td>
+                <td>
+                  {student.image && (
+                    <Image src={student.image} alt={`${student.name} 프로필 이미지`} className={styles.student_image} />
+                  )}
+                </td>
+                <td className={styles.name}>
+                  {student.name}
+                  {currentUser && student.id === currentUser.id && (
+                    <span className={styles.current_user_label}> (나)</span>
+                  )}
+                </td>
+                <td>{student.course}</td>
+                <td>{formatTime(student.studyTime)}</td>
+                <td>{formatTime(student.totalTime)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </InfiniteScroll>
     </div>
   );
 }
-
-export default FullRankingList;


### PR DESCRIPTION
## 📋 연관된 이슈 번호
- #64 

## 📚 변경 사항
- Grid 레이아웃 삭제 -> Flex 및 Box 컴포넌트로 변경
- 2개로 구분된 table 하나로 합침 -> 스크롤 발생시 여백 둬서 테이블 밀리는 현상 없게끔 수정
- 중복된 css 삭제
- box-shadow 옵션 잠시 꺼둠

## 🏜 스크린샷
- 화면 기준으로 ranking 요소가 부족해도 하단에 붙어있게끔 했습니다
![image](https://github.com/user-attachments/assets/3e5379c2-33b3-4341-8ac7-22ae8c36341a)
- 스크롤 발생시 다음과 같습니다
![image](https://github.com/user-attachments/assets/34264b31-b598-44f9-95a0-08451999505d)

## 💬 To Reviewers
- 공부기록이 갱신되면 TopRankings은 따로 PR 날릴게요!! 
- 컴포넌트 분리는 전혀 안하고 마크업과 css만 수정했습니다. 또한 어떤 방식으로 고쳤는지는 file changed 쪽에 코멘트를 달아두었으니 참고해주세요~ 