### PR TITLE
[feat/#76]: 스타일 점검

### DIFF
--- a/api/userApi.ts
+++ b/api/userApi.ts
@@ -1,0 +1,10 @@
+import { instance } from './instance';
+
+// 유저정보 조회
+export const getUserInfo = async () => {
+  const response = await instance(`members`, {
+    method: 'GET',
+  });
+
+  return response;
+};

--- a/app/mypage/layout.tsx
+++ b/app/mypage/layout.tsx
@@ -1,6 +1,7 @@
 import UserProfile from '@/components/mypage/UserProfile';
-import { Box, Container } from '@radix-ui/themes';
+import { Box, Container, Flex } from '@radix-ui/themes';
 import styles from './layout.module.css';
+import SmallButton from '@/components/common/SmallButton';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -12,6 +13,17 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       <Box mt="3" p="4" py="6" className={styles.inner} asChild>
         <section>{children}</section>
       </Box>
+      {/* 유저 유틸 버튼 */}
+      <Flex mt="3" justify="end" gap="10px" asChild>
+        <ul>
+          <li>
+            <SmallButton>로그아웃</SmallButton>
+          </li>
+          <li>
+            <SmallButton>회원탈퇴</SmallButton>
+          </li>
+        </ul>
+      </Flex>
     </Container>
   );
 }

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -12,34 +12,34 @@ export default function Mypage() {
         <Flex asChild justify="center" align="center" gap="65px">
           <ul>
             <li>
-              <Tooltip content={`7월 3주차`}>
-                <Box>
-                  <Image src={'/imgs/medal_first_on.svg'} width={120} height={150} alt="1등 뱃지" />
-                  <Text as="p" mt="3" weight="medium">
-                    1회
-                  </Text>
-                </Box>
-              </Tooltip>
+              {/* <Tooltip content={`7월 3주차`}> */}
+              <Box>
+                <Image src={'/imgs/medal_first_off.svg'} width={120} height={150} alt="1등 뱃지" />
+                <Text as="p" mt="3" weight="medium">
+                  0회
+                </Text>
+              </Box>
+              {/* </Tooltip> */}
             </li>
             <li>
-              <Tooltip content={`7월 3주차`}>
-                <Box>
-                  <Image src={'/imgs/medal_second_off.svg'} width={120} height={150} alt="2등 뱃지" />
-                  <Text as="p" mt="3" weight="medium">
-                    0회
-                  </Text>
-                </Box>
-              </Tooltip>
+              {/* <Tooltip content={`7월 3주차`}> */}
+              <Box>
+                <Image src={'/imgs/medal_second_off.svg'} width={120} height={150} alt="2등 뱃지" />
+                <Text as="p" mt="3" weight="medium">
+                  0회
+                </Text>
+              </Box>
+              {/* </Tooltip> */}
             </li>
             <li>
-              <Tooltip content={`7월 3주차`}>
-                <Box>
-                  <Image src={'/imgs/medal_third_off.svg'} width={120} height={150} alt="3등 뱃지" />
-                  <Text as="p" mt="3" weight="medium">
-                    0회
-                  </Text>
-                </Box>
-              </Tooltip>
+              {/* <Tooltip content={`7월 3주차`}> */}
+              <Box>
+                <Image src={'/imgs/medal_third_off.svg'} width={120} height={150} alt="3등 뱃지" />
+                <Text as="p" mt="3" weight="medium">
+                  0회
+                </Text>
+              </Box>
+              {/* </Tooltip> */}
             </li>
           </ul>
         </Flex>

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -38,9 +38,9 @@ export default function LoginForm({ onLogin }: LoginFormProps) {
           <CommonButton type="submit" style="dark_purple">
             로그인
           </CommonButton>
-          <Text as="p" align="right" mt="2">
+          {/* <Text as="p" align="right" mt="2">
             <Link href={'/pwfind'}>비밀번호 찾기</Link>
-          </Text>
+          </Text> */}
         </Box>
       </form>
       <Box mt="6" className="btn_join">

--- a/components/common/Header/Header.tsx
+++ b/components/common/Header/Header.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import { Avatar, Box, Flex, Heading, Strong, Text } from '@radix-ui/themes';
 import styles from './Header.module.css';
 import HeaderNav from './HeaderNav';
+import rankingImg from '@/assets/icons/ranking_profile_img.png';
+import Image from 'next/image';
 
 export default function Header() {
   return (
@@ -19,14 +21,16 @@ export default function Header() {
           <div className={styles.user_info}>
             <Flex align="center" gap="2" asChild>
               <Link href="/mypage">
-                {/* <div
+                <div
                   className={styles.user_name}
                   style={{
-                    backgroundImage: `url('https://images.unsplash.com/photo-1502823403499-6ccfcf4fb453?&w=256&h=256&q=70&crop=focalpoint&fp-x=0.5&fp-y=0.3&fp-z=1&fit=crop')`,
+                    // 유저 프로필 이미지
+                    backgroundImage: `url('')`,
                   }}
                 >
-                  <Avatar fallback="A" />
-                </div> */}
+                  {/* 기본 이미지 */}
+                  <Image src={rankingImg.src} alt={`프로필 이미지`} width={40} height={40} />
+                </div>
                 <div className={styles.user_txt}>
                   <Strong>홍길동</Strong>
                   <Text as="p" size="2" mt="1" weight="medium">

--- a/components/common/Header/Header.tsx
+++ b/components/common/Header/Header.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { Avatar, Box, Flex, Heading, Strong, Text } from '@radix-ui/themes';
+import { Box, Flex, Heading, Strong, Text } from '@radix-ui/themes';
 import styles from './Header.module.css';
 import HeaderNav from './HeaderNav';
 import rankingImg from '@/assets/icons/ranking_profile_img.png';
@@ -29,7 +29,7 @@ export default function Header() {
                   }}
                 >
                   {/* 기본 이미지 */}
-                  <Image src={rankingImg.src} alt={`프로필 이미지`} width={40} height={40} />
+                  <Image src={rankingImg} alt={`프로필 이미지`} width={40} height={40} />
                 </div>
                 <div className={styles.user_txt}>
                   <Strong>홍길동</Strong>

--- a/components/common/Header/Header.tsx
+++ b/components/common/Header/Header.tsx
@@ -19,14 +19,14 @@ export default function Header() {
           <div className={styles.user_info}>
             <Flex align="center" gap="2" asChild>
               <Link href="/mypage">
-                <div
+                {/* <div
                   className={styles.user_name}
                   style={{
                     backgroundImage: `url('https://images.unsplash.com/photo-1502823403499-6ccfcf4fb453?&w=256&h=256&q=70&crop=focalpoint&fp-x=0.5&fp-y=0.3&fp-z=1&fit=crop')`,
                   }}
                 >
                   <Avatar fallback="A" />
-                </div>
+                </div> */}
                 <div className={styles.user_txt}>
                   <Strong>홍길동</Strong>
                   <Text as="p" size="2" mt="1" weight="medium">

--- a/components/common/Header/HeaderNav.tsx
+++ b/components/common/Header/HeaderNav.tsx
@@ -14,14 +14,14 @@ export default function HeaderNav() {
         <li>
           <Link href="/study" className={pathname.startsWith('/study') ? `${styles.active}` : ''}>
             <Text as="p" size="4" weight="bold">
-              공부하기
+              공부시작
             </Text>
           </Link>
         </li>
         <li>
           <Link href="/ranking" className={pathname.startsWith('/ranking') ? `${styles.active}` : ''}>
             <Text as="p" size="4" weight="bold">
-              순위확인
+              순위조회
             </Text>
           </Link>
         </li>

--- a/components/common/Header/MobileHeader.tsx
+++ b/components/common/Header/MobileHeader.tsx
@@ -33,7 +33,7 @@ export default function MobileHeader() {
                   </svg>
                 </div>
                 <Text as="p" size="2" weight="medium" mt="2">
-                  공부하기
+                  공부시작
                 </Text>
               </Link>
             </li>
@@ -55,7 +55,7 @@ export default function MobileHeader() {
                   </svg>
                 </div>
                 <Text as="p" size="2" weight="medium" mt="2">
-                  순위확인
+                  순위조회
                 </Text>
               </Link>
             </li>

--- a/components/common/SmallButton.module.css
+++ b/components/common/SmallButton.module.css
@@ -1,0 +1,9 @@
+.btn_small {
+  display: block;
+  width: 60px;
+  height: 30px;
+  font-size: 12px;
+  border-radius: 4px;
+  background-color: #eee;
+  color: #999;
+}

--- a/components/common/SmallButton.tsx
+++ b/components/common/SmallButton.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import styles from './SmallButton.module.css';
+
+export default function SmallButton({ children }: { children: React.ReactNode }) {
+  return <button className={styles.btn_small}>{children}</button>;
+}

--- a/components/mypage/UserProfile.tsx
+++ b/components/mypage/UserProfile.tsx
@@ -43,8 +43,10 @@ export default function UserProfile() {
     <section className="user_profile">
       <div className={styles.user_info}>
         <div className={styles.img_box}>
-          <div className={styles.back_img} style={{ backgroundImage: `url(${imgUrl ? imgUrl : rankingImg.src})` }}>
-            <Avatar size="8" fallback="" radius="full"></Avatar>
+          {/* 유저 프로필 이미지 */}
+          <div className={styles.back_img} style={{ backgroundImage: `url(${imgUrl ? imgUrl : ''})` }}>
+            {/* 기본 이미지 */}
+            <Image src={rankingImg} alt={`프로필 이미지`} width={180} height={180} />
           </div>
           {/* <div className={styles.btn_file}>
             <input type="file" ref={imgRef} onChange={onChangeImage} />

--- a/components/mypage/UserProfile.tsx
+++ b/components/mypage/UserProfile.tsx
@@ -7,6 +7,8 @@ import ico_profile_img_file from '@/assets/icons/profile_img_file.png';
 import Image from 'next/image';
 import MypageTabMenu from './MypageTabMenu';
 
+import rankingImg from '@/assets/icons/ranking_profile_img.png';
+
 export default function UserProfile() {
   const [imgUrl, setImgUrl] = useState('');
   const imgRef = useRef<HTMLInputElement>(null);
@@ -41,15 +43,15 @@ export default function UserProfile() {
     <section className="user_profile">
       <div className={styles.user_info}>
         <div className={styles.img_box}>
-          <div className={styles.back_img} style={{ backgroundImage: `url(${imgUrl ? imgUrl : ''})` }}>
+          <div className={styles.back_img} style={{ backgroundImage: `url(${imgUrl ? imgUrl : rankingImg.src})` }}>
             <Avatar size="8" fallback="" radius="full"></Avatar>
           </div>
-          <div className={styles.btn_file}>
+          {/* <div className={styles.btn_file}>
             <input type="file" ref={imgRef} onChange={onChangeImage} />
             <button onClick={imageChangeHandler}>
               <Image src={ico_profile_img_file} alt="프로필 이미지 변경하기" width={18} height={18} />
             </button>
-          </div>
+          </div> */}
         </div>
         <Box mt="3" className={styles.txt_box}>
           <Strong>홍길동</Strong>

--- a/components/record/FullCalendar.module.css
+++ b/components/record/FullCalendar.module.css
@@ -1,4 +1,9 @@
 /* container */
+.full_calendar {
+  min-width: 944px;
+  overflow-x: auto;
+}
+
 .container_inner {
   border-radius: 10px;
   background-color: #fff;


### PR DESCRIPTION
## 📋 연관된 이슈 번호
- close #76

## 🛠 구현 사항
- `<SmallButton>` 컴포넌트 생성
- 유저정보조회 api 생성
    - 추후 로그인 로직에 스토리지 저장하는 부분 추가

## 📚 변경 사항
- 안보일 요소들 주석처리
- 헤더 및 마이페이지에 기본 이미지 설정
    - 이미지 변경 버튼 주석처리
- 헤더 (pc, mobile)에 주메뉴명 수정 
    - 공부하기, 순위확인, 기록확인 -> 공부시작, 순위조회, 기록확인
- 기록확인 페이지 가로 스크롤 처리

## 💬 To Reviewers
- 랭킹 페이지는 TopRanking 컴포넌트 레이아웃 잡을때 수정할게요
- 랭킹에서 사용하는 기본 이미지가 백터가 아닌것 같아요... 그리고 미묘하게 찌그러지는데 (마이페이지에서 크게보면 확인가능) 새로 svg를 추출하는게 좋아보입니다!! 
