### PR TITLE
[feat/#81]: 마이페이지 비밀번호 수정 API 연결

### DIFF
--- a/api/memberApi.ts
+++ b/api/memberApi.ts
@@ -1,0 +1,10 @@
+import { instance } from './instance';
+
+// 비밀번호 업데이트
+export const postPwUpdate = async ({ oldPassword, newPassword }: { oldPassword: string; newPassword: string }) => {
+  const response = await instance('members', {
+    body: JSON.stringify({ oldPassword, newPassword }),
+    method: 'POST',
+  });
+  return response;
+};

--- a/app/mypage/pwupdate/page.tsx
+++ b/app/mypage/pwupdate/page.tsx
@@ -1,42 +1,29 @@
-import CommonButton from '@/components/common/CommonButton';
-import { Box, Text } from '@radix-ui/themes';
+'use client';
+
+import { postPwUpdate } from '@/api/memberApi';
+import PwUpdateForm from '@/components/mypage/PwUpdateForm';
+import { usePwUpdateStore } from '@/store/memberStore';
 
 export default function PwUpdate() {
-  return (
-    <>
-      <Box className="form_box">
-        <form action="">
-          <Box className="row">
-            <Text as="label" weight="medium">
-              현재 비밀번호
-            </Text>
-            <Box mt="2">
-              <input type="password" placeholder="현재 비밀번호를 입력해주세요." />
-            </Box>
-          </Box>
-          <Box mt="3" className="row">
-            <Text as="label" weight="medium">
-              새 비밀번호
-            </Text>
-            <Box mt="2">
-              <input type="password" placeholder="새로운 비밀번호를 입력해주세요." />
-            </Box>
-          </Box>
-          <Box mt="3" className="row">
-            <Text as="label" weight="medium">
-              새 비밀번호 확인
-            </Text>
-            <Box mt="2">
-              <input type="password" placeholder="새 비밀번호를 다시 한 번 입력해주세요." />
-            </Box>
-          </Box>
-          <Box mt="6">
-            <CommonButton type="submit" style="dark_purple">
-              저장
-            </CommonButton>
-          </Box>
-        </form>
-      </Box>
-    </>
-  );
+  const { oldPassword, newPassword, setAllEmpty } = usePwUpdateStore();
+  const updateHandler = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const pwUpdateResponse = await postPwUpdate({ oldPassword, newPassword });
+
+    if (pwUpdateResponse?.error) {
+      if (pwUpdateResponse.error.errors) {
+        const errorMessages = pwUpdateResponse.error.errors
+          .map((error: { field: string; message: string }) => error.message)
+          .join('\n');
+        alert(errorMessages);
+      } else {
+        alert(pwUpdateResponse.error.message);
+      }
+    } else {
+      alert('성공적으로 비밀번호가 변경 되었습니다.');
+      setAllEmpty();
+    }
+  };
+  return <PwUpdateForm onUpdate={updateHandler} />;
 }

--- a/components/mypage/PwUpdateForm.tsx
+++ b/components/mypage/PwUpdateForm.tsx
@@ -1,14 +1,47 @@
 import { Box, Text } from '@radix-ui/themes';
 import CommonButton from '@/components/common/CommonButton';
 import { usePwUpdateStore } from '@/store/memberStore';
+import { useState } from 'react';
+import { isValidPassword } from '@/utils/validateUtils';
 
 interface IUpdateForm {
   onUpdate: (e: React.FormEvent<HTMLFormElement>) => void;
 }
 
 export default function PwUpdateForm({ onUpdate }: IUpdateForm) {
+  const [error, setError] = useState({ oldPassword: false, newPassword: false, checkPassword: false });
   const { oldPassword, newPassword, checkPassword, setOldPassword, setNewPassword, setCheckPassword } =
     usePwUpdateStore();
+
+  const newPasswordChangeHandler = (newPassword: string) => {
+    setNewPassword(newPassword);
+
+    // 비밀번호 유효성 검사
+    if (isValidPassword(newPassword)) {
+      setError((prev) => ({ ...prev, newPassword: false }));
+    } else {
+      setError((prev) => ({ ...prev, newPassword: true }));
+    }
+
+    // 새 비밀번호와 비밀번호 확인 일치 여부 검사
+    checkPasswordMatch(newPassword, checkPassword);
+  };
+
+  const checkPasswordChangeHandler = (checkPassword: string) => {
+    console.log('test');
+    setCheckPassword(checkPassword);
+
+    // 새 비밀번호와 비밀번호 확인 일치 여부 검사
+    checkPasswordMatch(newPassword, checkPassword);
+  };
+
+  // 비밀번호와 비밀번호 확인 일치 여부를 검사하는 함수
+  const checkPasswordMatch = (newPassword: string, checkPassword: string) => {
+    setError((prev) => ({
+      ...prev,
+      checkPassword: newPassword !== checkPassword,
+    }));
+  };
 
   return (
     <Box className="form_box">
@@ -38,18 +71,35 @@ export default function PwUpdateForm({ onUpdate }: IUpdateForm) {
               placeholder="새로운 비밀번호를 입력해주세요."
               value={newPassword}
               onChange={(e) => {
-                setNewPassword(e.target.value);
+                newPasswordChangeHandler(e.target.value);
               }}
             />
           </Box>
+          {error.newPassword && (
+            <Text as="p" color="red" size="2" weight="medium" mt="2" ml="2">
+              영어, 숫자, 특수문자를 포함한 최소 8자 이상, 최대 20자 이하여야 합니다.
+            </Text>
+          )}
         </Box>
         <Box mt="3" className="row">
           <Text as="label" weight="medium">
             새 비밀번호 확인
           </Text>
           <Box mt="2">
-            <input type="password" placeholder="새 비밀번호를 다시 한 번 입력해주세요." />
+            <input
+              type="password"
+              placeholder="새 비밀번호를 다시 한 번 입력해주세요."
+              value={checkPassword}
+              onChange={(e) => {
+                checkPasswordChangeHandler(e.target.value);
+              }}
+            />
           </Box>
+          {error.checkPassword && (
+            <Text as="p" color="red" size="2" weight="medium" mt="2" ml="2">
+              새 비밀번호가 일치하지 않습니다.
+            </Text>
+          )}
         </Box>
         <Box mt="6">
           <CommonButton type="submit" style="dark_purple">

--- a/components/mypage/PwUpdateForm.tsx
+++ b/components/mypage/PwUpdateForm.tsx
@@ -1,0 +1,62 @@
+import { Box, Text } from '@radix-ui/themes';
+import CommonButton from '@/components/common/CommonButton';
+import { usePwUpdateStore } from '@/store/memberStore';
+
+interface IUpdateForm {
+  onUpdate: (e: React.FormEvent<HTMLFormElement>) => void;
+}
+
+export default function PwUpdateForm({ onUpdate }: IUpdateForm) {
+  const { oldPassword, newPassword, checkPassword, setOldPassword, setNewPassword, setCheckPassword } =
+    usePwUpdateStore();
+
+  return (
+    <Box className="form_box">
+      <form onSubmit={onUpdate}>
+        <Box className="row">
+          <Text as="label" weight="medium">
+            현재 비밀번호
+          </Text>
+          <Box mt="2">
+            <input
+              type="password"
+              placeholder="현재 비밀번호를 입력해주세요."
+              value={oldPassword}
+              onChange={(e) => {
+                setOldPassword(e.target.value);
+              }}
+            />
+          </Box>
+        </Box>
+        <Box mt="3" className="row">
+          <Text as="label" weight="medium">
+            새 비밀번호
+          </Text>
+          <Box mt="2">
+            <input
+              type="password"
+              placeholder="새로운 비밀번호를 입력해주세요."
+              value={newPassword}
+              onChange={(e) => {
+                setNewPassword(e.target.value);
+              }}
+            />
+          </Box>
+        </Box>
+        <Box mt="3" className="row">
+          <Text as="label" weight="medium">
+            새 비밀번호 확인
+          </Text>
+          <Box mt="2">
+            <input type="password" placeholder="새 비밀번호를 다시 한 번 입력해주세요." />
+          </Box>
+        </Box>
+        <Box mt="6">
+          <CommonButton type="submit" style="dark_purple">
+            저장
+          </CommonButton>
+        </Box>
+      </form>
+    </Box>
+  );
+}

--- a/components/mypage/PwUpdateForm.tsx
+++ b/components/mypage/PwUpdateForm.tsx
@@ -13,10 +13,21 @@ export default function PwUpdateForm({ onUpdate }: IUpdateForm) {
   const { oldPassword, newPassword, checkPassword, setOldPassword, setNewPassword, setCheckPassword } =
     usePwUpdateStore();
 
+  // 기존 비밀번호 유효성 검사
+  const oldPasswordChangeHandler = (oldPassword: string) => {
+    setOldPassword(oldPassword);
+
+    if (isValidPassword(oldPassword)) {
+      setError((prev) => ({ ...prev, oldPassword: false }));
+    } else {
+      setError((prev) => ({ ...prev, oldPassword: true }));
+    }
+  };
+
+  // 새 비밀번호 유효성 검사
   const newPasswordChangeHandler = (newPassword: string) => {
     setNewPassword(newPassword);
 
-    // 비밀번호 유효성 검사
     if (isValidPassword(newPassword)) {
       setError((prev) => ({ ...prev, newPassword: false }));
     } else {
@@ -27,15 +38,15 @@ export default function PwUpdateForm({ onUpdate }: IUpdateForm) {
     checkPasswordMatch(newPassword, checkPassword);
   };
 
+  // 새 비밀번호 확인 검사
   const checkPasswordChangeHandler = (checkPassword: string) => {
-    console.log('test');
     setCheckPassword(checkPassword);
 
     // 새 비밀번호와 비밀번호 확인 일치 여부 검사
     checkPasswordMatch(newPassword, checkPassword);
   };
 
-  // 비밀번호와 비밀번호 확인 일치 여부를 검사하는 함수
+  // 새 비밀번호와 새 비밀번호 확인 일치 여부를 검사하는 함수
   const checkPasswordMatch = (newPassword: string, checkPassword: string) => {
     setError((prev) => ({
       ...prev,
@@ -43,9 +54,20 @@ export default function PwUpdateForm({ onUpdate }: IUpdateForm) {
     }));
   };
 
+  // submit 전에 frontend에서 입력값 검사
+  const submitHandler = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (error.oldPassword || error.newPassword || error.checkPassword) {
+      alert('입력값을 확인해주세요.');
+      return;
+    }
+    onUpdate(e);
+  };
+
   return (
     <Box className="form_box">
-      <form onSubmit={onUpdate}>
+      <form onSubmit={submitHandler}>
         <Box className="row">
           <Text as="label" weight="medium">
             현재 비밀번호
@@ -56,10 +78,15 @@ export default function PwUpdateForm({ onUpdate }: IUpdateForm) {
               placeholder="현재 비밀번호를 입력해주세요."
               value={oldPassword}
               onChange={(e) => {
-                setOldPassword(e.target.value);
+                oldPasswordChangeHandler(e.target.value);
               }}
             />
           </Box>
+          {error.oldPassword && (
+            <Text as="p" color="red" size="2" weight="medium" mt="2" ml="2">
+              영어, 숫자, 특수문자를 포함한 최소 8자 이상, 최대 20자 이하여야 합니다.
+            </Text>
+          )}
         </Box>
         <Box mt="3" className="row">
           <Text as="label" weight="medium">

--- a/store/memberStore.ts
+++ b/store/memberStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+interface PwUpdateState {
+  oldPassword: string;
+  newPassword: string;
+  checkPassword: string;
+  setOldPassword: (oldPassword: string) => void;
+  setNewPassword: (newPassword: string) => void;
+  setCheckPassword: (newPassword: string) => void;
+  setAllEmpty: () => void;
+}
+
+export const usePwUpdateStore = create<PwUpdateState>((set) => ({
+  oldPassword: '',
+  newPassword: '',
+  checkPassword: '',
+  setOldPassword: (oldPassword: string) => set({ oldPassword }),
+  setNewPassword: (newPassword: string) => set({ newPassword }),
+  setCheckPassword: (checkPassword: string) => set({ checkPassword }),
+  setAllEmpty: () => set({ oldPassword: '', newPassword: '', checkPassword: '' }),
+}));

--- a/store/memberStore.ts
+++ b/store/memberStore.ts
@@ -6,7 +6,7 @@ interface PwUpdateState {
   checkPassword: string;
   setOldPassword: (oldPassword: string) => void;
   setNewPassword: (newPassword: string) => void;
-  setCheckPassword: (newPassword: string) => void;
+  setCheckPassword: (checkPassword: string) => void;
   setAllEmpty: () => void;
 }
 


### PR DESCRIPTION
## 📋 연관된 이슈 번호
- close #81 

## 🛠 구현 사항
- 비밀번호 수정 API 연결
- 비밀번호 유효성 검사 

## 📚 변경 사항
- 유저정보 조회도 API 요청 주소가 똑같길래 `(.../members/...)` 추후 memberApi로 병합할게요~

## 🏜 스크린샷
![image](https://github.com/user-attachments/assets/8fa89131-0802-484d-842c-d5e83cbe6da0)

## 💬 To Reviewers
- 로그인 ~ 회원가입 로직을 많이 참고해서 거의 가져다 썼습니다!
