### PR TITLE
[fix/#58]:마이페이지 과목편집 새로고침 시 데이터저장

### DIFF
--- a/app/mypage/subjectedit/page.tsx
+++ b/app/mypage/subjectedit/page.tsx
@@ -1,14 +1,15 @@
 // Page.tsx
 'use client';
 
-import SubjectEdit from '@/components/study/SubjectEditForm';
+import SubjectEditForm from '@/components/study/SubjectEditForm';
 import { useSubjectStore } from '@/store/subjectStore';
 export default function Page() {
-  // Zustand 스토어에서 상태와 액션 가져오기
+
   const { setEditing, saveEditing } = useSubjectStore((state) => ({
     setEditing: state.setEditing,
     saveEditing: state.saveEditing,
   }));
+  
   const customStyle = {
     height: '400px',
   };
@@ -20,7 +21,7 @@ export default function Page() {
     fontWeight: '700',
   };
   return (
-    <SubjectEdit
+    <SubjectEditForm
       onSaveEditing={() => {
         saveEditing();
         setEditing(false);

--- a/app/mypage/subjectedit/page.tsx
+++ b/app/mypage/subjectedit/page.tsx
@@ -4,12 +4,11 @@
 import SubjectEditForm from '@/components/study/SubjectEditForm';
 import { useSubjectStore } from '@/store/subjectStore';
 export default function Page() {
-
   const { setEditing, saveEditing } = useSubjectStore((state) => ({
     setEditing: state.setEditing,
     saveEditing: state.saveEditing,
   }));
-  
+
   const customStyle = {
     height: '400px',
   };

--- a/components/common/Modal/Modal.module.css
+++ b/components/common/Modal/Modal.module.css
@@ -1,13 +1,13 @@
 /* modal_content */
 .modal_content {
-  margin:-24px 0;
+  margin: -24px 0;
 }
 
 /* modal_header */
 .modal_header {
   height: 60px;
   padding: 0 24px;
-  border-bottom: 1px solid #DDE1EB;
+  border-bottom: 1px solid #dde1eb;
   box-sizing: border-box;
 }
 .modal_header > div {
@@ -45,14 +45,14 @@
   font-size: 20px;
 }
 .modal_body .title strong:before {
-  content: "";
+  content: '';
   display: block;
   position: absolute;
   left: -5px;
   right: -5px;
   bottom: -2px;
   height: 12px;
-  background-color: #DBDBFF;
+  background-color: #dbdbff;
   z-index: -1;
 }
 .modal_body .list ul li {
@@ -61,7 +61,7 @@
   font-size: 14px;
 }
 .modal_body .list ul li:before {
-  content: "";
+  content: '';
   display: block;
   position: absolute;
   left: 0;
@@ -75,7 +75,7 @@
 /* modal_footer */
 .modal_footer {
   height: 40px;
-  padding:0 24px;
+  padding: 0 24px;
   background-color: var(--main-color-3);
 }
 .modal_footer label {

--- a/components/common/Modal/ModalLink.module.css
+++ b/components/common/Modal/ModalLink.module.css
@@ -1,11 +1,11 @@
 .link {
   display: inline-block;
   gap: 3px;
-  padding: 0 10px; 
+  padding: 0 10px;
   height: 24px;
   line-height: 22px;
   border-radius: 4px;
-  border: 1px solid #7667DC;
+  border: 1px solid #7667dc;
   font-size: 0;
   box-sizing: border-box;
 }
@@ -15,7 +15,7 @@
   padding-right: 20px;
   font-size: 14px;
   line-height: 22px;
-  color: #7667DC;
+  color: #7667dc;
 }
 .link span:before {
   content: '';

--- a/components/study/SubjectEditForm.tsx
+++ b/components/study/SubjectEditForm.tsx
@@ -4,6 +4,8 @@ import { Text } from '@radix-ui/themes';
 import styles from './SubjectForm.module.css';
 import { useSubjectStore } from '@/store/subjectStore';
 import { subjectFormApi } from '@/api/subjectFormApi'; // API 함수 임포트
+import { fetchSubjects } from '@/api/subjectFormApi';
+import useSWR from 'swr';
 
 export default function SubjectEditForm({
   onSaveEditing,
@@ -25,18 +27,25 @@ export default function SubjectEditForm({
     subjects,
     addSubject,
     deleteSubject,
-    setInitialSubjects,
     revertChanges,
     setEditing,
     resetAddedSubjects,
     resetDeletedSubjects,
     addedSubjects,
     deletedSubjects,
+    setSubjects,
   } = useSubjectStore();
 
-  useEffect(() => {
-    setInitialSubjects(); // 컴포넌트가 마운트될 때 초기 과목 상태를 저장
-  }, []);
+  // SWR을 사용하여 과목 데이터를 가져오고 동기화
+  const { data, error } = useSWR('subjects', fetchSubjects, {
+    onSuccess: (data) => {
+      setSubjects(data.subjects);
+    },
+  });
+
+  if (error) {
+    console.error('Failed to load subjects:', error);
+  }
 
   const handleAddSubject = () => {
     if (newSubjectName.trim() !== '') {
@@ -104,7 +113,7 @@ export default function SubjectEditForm({
           </button>
         </div>
         <div className={styles.subject_choice_box} style={subjectChoiceBoxStyle}>
-          {subjects.map((subject) => (
+          {subjects?.map((subject) => (
             <div key={subject.id} className={styles.subject_item}>
               <Text as="p" size="3" className={styles.subject_item_text}>
                 {subject.name}
@@ -120,16 +129,13 @@ export default function SubjectEditForm({
         <button
           type="submit"
           className={styles.subject_edit_form_btn_save}
-          onClick={handleSaveEditing} // 수정된 핸들러 사용
+          onClick={handleSaveEditing}
           style={saveButtonStyle}
         >
           저장
         </button>
         {showCancelButton && (
-          <button
-            className={styles.subject_edit_form_btn_modify}
-            onClick={handleCancelEditing} // 수정된 핸들러 사용
-          >
+          <button className={styles.subject_edit_form_btn_modify} onClick={handleCancelEditing}>
             취소
           </button>
         )}


### PR DESCRIPTION
## 📋 연관된 이슈 번호
 - #58 

## 🛠 구현 사항
- 마이페이지 새로 고침 시 과목 편집 데이터 저장: getTimer api불러옴
- useEffect 대신 useSWR로 교체

## 💬 To Reviewers
- 찾은 문제1: 과목 편집에서 똑같은 명칭으로 과목 추가하고 삭제하면 업데이트 실패가 뜸 / 그리고 새로 고침 하면 다시 정상 작동
- 찾은 문제2: 과목명 엄청 길게 쓰면 삭제 버튼이 오른쪽으로 밀려서 사라짐 
- 추후에 할 것 : store 분리 작업 + id값까지 같이 저장, 과목 선택 get api 받아 오기, 문제 고치기 
