### PR TITLE
[feat/#88]: 유저정보 API 연결

### DIFF
--- a/app/mypage/layout.tsx
+++ b/app/mypage/layout.tsx
@@ -20,6 +20,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     Cookies.remove('access_token');
     Cookies.remove('refresh_token');
 
+    // 유저 정보 삭제
+    localStorage.removeItem('userInfo');
+
     route.push('/login');
   };
 

--- a/app/mypage/layout.tsx
+++ b/app/mypage/layout.tsx
@@ -7,9 +7,11 @@ import SmallButton from '@/components/common/SmallButton';
 import Cookies from 'js-cookie';
 import { signOut } from '@/api/authApi';
 import { useRouter } from 'next/navigation';
+import { useUserInfoStore } from '@/store/memberStore';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const route = useRouter();
+  const { setUserInfo } = useUserInfoStore();
 
   const logoutHandler = async () => {
     // 로그아웃할건지 확인하는 모달창 띄우기
@@ -22,6 +24,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
     // 유저 정보 삭제
     localStorage.removeItem('userInfo');
+    setUserInfo(null);
 
     route.push('/login');
   };

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -6,6 +6,9 @@ import { Box, Text } from '@radix-ui/themes';
 import AuthFormLayout from './AuthFormLayout';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { getUserInfo } from '@/api/memberApi';
+import Cookies from 'js-cookie';
+import useSWR from 'swr';
 
 interface LoginFormProps {
   onLogin: (email: string, password: string) => Promise<Response>;
@@ -36,6 +39,13 @@ export default function LoginForm({ onLogin }: LoginFormProps) {
       alert('로그인에 성공했습니다.');
     }
   };
+
+  // 유저정보조회
+  const accessToken = Cookies.get('access_token');
+  const { data } = useSWR(accessToken ? ['userInfo'] : null, async () => {
+    const result = await getUserInfo();
+    localStorage.setItem('userInfo', JSON.stringify({ name: result.name, course: result.course, image: result.image }));
+  });
 
   return (
     <AuthFormLayout title="로그인">

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation';
 import { getUserInfo } from '@/api/memberApi';
 import Cookies from 'js-cookie';
 import useSWR from 'swr';
+import { useUserInfoStore } from '@/store/memberStore';
 
 interface LoginFormProps {
   onLogin: (email: string, password: string) => Promise<Response>;
@@ -42,9 +43,12 @@ export default function LoginForm({ onLogin }: LoginFormProps) {
 
   // 유저정보조회
   const accessToken = Cookies.get('access_token');
+  const { setUserInfo } = useUserInfoStore();
   const { data } = useSWR(accessToken ? ['userInfo'] : null, async () => {
     const result = await getUserInfo();
-    localStorage.setItem('userInfo', JSON.stringify({ name: result.name, course: result.course, image: result.image }));
+    const storedUserInfo = { name: result.name, course: result.course, image: result.image };
+    localStorage.setItem('userInfo', JSON.stringify(storedUserInfo));
+    setUserInfo(storedUserInfo);
   });
 
   return (

--- a/components/common/Header/Header.tsx
+++ b/components/common/Header/Header.tsx
@@ -11,9 +11,11 @@ import Cookies from 'js-cookie';
 import { API_ROUTE_URL } from '@/constants/url';
 import useSWR from 'swr';
 import useUserInfo from '@/hook/useUserInfo';
+import { useUserInfoStore } from '@/store/memberStore';
 
 export default function Header() {
   useSWR('reissue-token', revaildateToken);
+  const { setUserInfo } = useUserInfoStore();
 
   // eslint-disable-next-line func-style
   async function revaildateToken() {
@@ -39,18 +41,16 @@ export default function Header() {
 
       // 토큰을 성공적으로 재발급받은 후 페이지 리로드
       window.location.reload();
-
       return data;
     }
 
-    // if (!accessToken && !refreshToken) {
-    //   // 유저 정보 삭제
-    //   localStorage.removeItem('userInfo');
-    // }
+    if (!accessToken && !refreshToken) {
+      localStorage.removeItem('userInfo');
+      setUserInfo(null);
+    }
   }
 
   const userInfo = useUserInfo();
-  console.log(userInfo);
 
   return (
     <Box px="5" asChild>

--- a/components/common/Header/Header.tsx
+++ b/components/common/Header/Header.tsx
@@ -10,6 +10,7 @@ import Image from 'next/image';
 import Cookies from 'js-cookie';
 import { API_ROUTE_URL } from '@/constants/url';
 import useSWR from 'swr';
+import useUserInfo from '@/hook/useUserInfo';
 
 export default function Header() {
   useSWR('reissue-token', revaildateToken);
@@ -41,7 +42,15 @@ export default function Header() {
 
       return data;
     }
+
+    // if (!accessToken && !refreshToken) {
+    //   // 유저 정보 삭제
+    //   localStorage.removeItem('userInfo');
+    // }
   }
+
+  const userInfo = useUserInfo();
+  console.log(userInfo);
 
   return (
     <Box px="5" asChild>
@@ -55,28 +64,30 @@ export default function Header() {
           <nav className={styles.gnb}>
             <HeaderNav />
           </nav>
-          <div className={styles.user_info}>
-            <Flex align="center" gap="2" asChild>
-              <Link href="/mypage">
-                <div
-                  className={styles.user_name}
-                  style={{
-                    // 유저 프로필 이미지
-                    backgroundImage: `url('')`,
-                  }}
-                >
-                  {/* 기본 이미지 */}
-                  <Image src={rankingImg} alt={`프로필 이미지`} width={40} height={40} />
-                </div>
-                <div className={styles.user_txt}>
-                  <Strong>홍길동</Strong>
-                  <Text as="p" size="2" mt="1" weight="medium">
-                    클라우드 서비스
-                  </Text>
-                </div>
-              </Link>
-            </Flex>
-          </div>
+          {userInfo && (
+            <div className={styles.user_info}>
+              <Flex align="center" gap="2" asChild>
+                <Link href="/mypage">
+                  <div
+                    className={styles.user_name}
+                    style={{
+                      // 유저 프로필 이미지
+                      backgroundImage: `url('')`,
+                    }}
+                  >
+                    {/* 기본 이미지 */}
+                    <Image src={rankingImg} alt={`프로필 이미지`} width={40} height={40} />
+                  </div>
+                  <div className={styles.user_txt}>
+                    <Strong>{userInfo?.name}</Strong>
+                    <Text as="p" size="2" mt="1" weight="medium">
+                      {userInfo?.course}
+                    </Text>
+                  </div>
+                </Link>
+              </Flex>
+            </div>
+          )}
         </Box>
       </header>
     </Box>

--- a/components/mypage/UserProfile.tsx
+++ b/components/mypage/UserProfile.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { Avatar, Box, Strong, Text } from '@radix-ui/themes';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styles from './UserProfile.module.css';
 import ico_profile_img_file from '@/assets/icons/profile_img_file.png';
 import Image from 'next/image';
 import MypageTabMenu from './MypageTabMenu';
 
 import rankingImg from '@/assets/icons/ranking_profile_img.png';
+import useUserInfo from '@/hook/useUserInfo';
 
 export default function UserProfile() {
   const [imgUrl, setImgUrl] = useState('');
@@ -39,6 +40,8 @@ export default function UserProfile() {
     }
   };
 
+  const userInfo = useUserInfo();
+
   return (
     <section className="user_profile">
       <div className={styles.user_info}>
@@ -56,9 +59,9 @@ export default function UserProfile() {
           </div> */}
         </div>
         <Box mt="3" className={styles.txt_box}>
-          <Strong>홍길동</Strong>
+          <Strong>{userInfo?.name}</Strong>
           <Text as="p" size="3" weight="medium">
-            클라우드 서비스
+            {userInfo?.course}
           </Text>
         </Box>
       </div>

--- a/components/mypage/UserProfile.tsx
+++ b/components/mypage/UserProfile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Avatar, Box, Strong, Text } from '@radix-ui/themes';
-import { useEffect, useRef, useState } from 'react';
+import { Box, Strong, Text } from '@radix-ui/themes';
+import { useRef, useState } from 'react';
 import styles from './UserProfile.module.css';
 import ico_profile_img_file from '@/assets/icons/profile_img_file.png';
 import Image from 'next/image';

--- a/components/record/FullCalendar.tsx
+++ b/components/record/FullCalendar.tsx
@@ -7,8 +7,7 @@ import styles from './FullCalendar.module.css';
 import MonthPicker from './MonthPicker';
 import { useSelectedMonthStore, useSelectedYearStore, useTodayStore } from '@/store/recordStore';
 import CalendarRecord from './CalendarRecord';
-import { getRecordMonthly } from '@/api/recordApi';
-import useSWR from 'swr';
+import useRefreshMonthlyData from '@/hook/useRefreshMonthlyData';
 
 interface IMonthlyData {
   year: number;
@@ -21,27 +20,6 @@ interface IMonthlyDataRecord {
   time: number;
   subjects: any[];
 }
-
-// 달력 이동 버튼을 누를때만 갱신된 데이터 가져옴
-const useRefreshMonthyData = (selectedYear: number, selectedMonth: number, shouldFetch: boolean) => {
-  const { data: refreshMonthlyData, isLoading: refreshMonthlyLoading } = useSWR(
-    shouldFetch ? ['MonthlyRecord', selectedYear, selectedMonth] : null,
-    async () => {
-      const result = await getRecordMonthly(selectedYear, selectedMonth);
-      return result;
-    },
-    {
-      revalidateOnFocus: false, // 화면이 포커스될 때 데이터 재요청 방지
-      revalidateOnReconnect: false, // 네트워크 재연결 시 데이터 재요청 방지
-    },
-  );
-
-  if (refreshMonthlyData?.error) {
-    alert(refreshMonthlyData.error.message);
-  }
-
-  return { refreshMonthlyData, refreshMonthlyLoading };
-};
 
 export default function FullCalendar({ monthlyData }: { monthlyData: IMonthlyData }) {
   const today = useTodayStore();
@@ -60,7 +38,7 @@ export default function FullCalendar({ monthlyData }: { monthlyData: IMonthlyDat
   const weekNumber = Math.ceil((startDay + endDate) / 7);
 
   // 커스텀 훅 호출
-  const { refreshMonthlyData, refreshMonthlyLoading } = useRefreshMonthyData(selectedYear, selectedMonth, shouldFetch);
+  const { refreshMonthlyData, refreshMonthlyLoading } = useRefreshMonthlyData(selectedYear, selectedMonth, shouldFetch);
 
   // 이전달 보기
   const prevMonth = useCallback(async () => {

--- a/hook/useRefreshMonthlyData.ts
+++ b/hook/useRefreshMonthlyData.ts
@@ -1,0 +1,25 @@
+import { getRecordMonthly } from '@/api/recordApi';
+import useSWR from 'swr';
+
+// 달력 이동 버튼을 누를때만 갱신된 데이터 가져옴
+const useRefreshMonthlyData = (selectedYear: number, selectedMonth: number, shouldFetch: boolean) => {
+  const { data: refreshMonthlyData, isLoading: refreshMonthlyLoading } = useSWR(
+    shouldFetch ? ['MonthlyRecord', selectedYear, selectedMonth] : null,
+    async () => {
+      const result = await getRecordMonthly(selectedYear, selectedMonth);
+      return result;
+    },
+    {
+      revalidateOnFocus: false, // 화면이 포커스될 때 데이터 재요청 방지
+      revalidateOnReconnect: false, // 네트워크 재연결 시 데이터 재요청 방지
+    },
+  );
+
+  if (refreshMonthlyData?.error) {
+    alert(refreshMonthlyData.error.message);
+  }
+
+  return { refreshMonthlyData, refreshMonthlyLoading };
+};
+
+export default useRefreshMonthlyData;

--- a/hook/useUserInfo.ts
+++ b/hook/useUserInfo.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+interface UserInfo {
+  name: string;
+  course: string;
+}
+const useUserInfo = () => {
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+
+  useEffect(() => {
+    const storedUserInfo = localStorage.getItem('userInfo');
+    if (storedUserInfo) {
+      setUserInfo(JSON.parse(storedUserInfo));
+    }
+  }, []);
+
+  return userInfo;
+};
+
+export default useUserInfo;

--- a/hook/useUserInfo.ts
+++ b/hook/useUserInfo.ts
@@ -1,18 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useUserInfoStore } from '@/store/memberStore';
+import { useEffect } from 'react';
 
-interface UserInfo {
-  name: string;
-  course: string;
-}
 const useUserInfo = () => {
-  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const { userInfo, setUserInfo } = useUserInfoStore();
 
   useEffect(() => {
     const storedUserInfo = localStorage.getItem('userInfo');
     if (storedUserInfo) {
       setUserInfo(JSON.parse(storedUserInfo));
     }
-  }, []);
+  }, [setUserInfo]);
 
   return userInfo;
 };

--- a/store/memberStore.ts
+++ b/store/memberStore.ts
@@ -1,5 +1,22 @@
 import { create } from 'zustand';
 
+// 유저정보 조회
+interface IuserInfo {
+  name: string;
+  course: string;
+}
+
+interface UserInfoState {
+  userInfo: IuserInfo | null;
+  setUserInfo: (userInfo: IuserInfo | null) => void;
+}
+
+export const useUserInfoStore = create<UserInfoState>((set) => ({
+  userInfo: null,
+  setUserInfo: (userInfo: IuserInfo | null) => set({ userInfo }),
+}));
+
+// 비밀번호 수정
 interface PwUpdateState {
   oldPassword: string;
   newPassword: string;


### PR DESCRIPTION
## 📋 연관된 이슈 번호
- #88

## 🛠 구현 사항
- 로그인 → 유저정보 로컬 스토리지에 저장
- 토큰만료, 로그아웃 → 유저정보 로컬 스토리지에서 삭제
- 로컬 스토리지 존재하면 → 헤더 및 마이페이지에서 데이터 바인딩 

## 📚 변경 사항
- 커스텀 훅을 정리해두는 hook 폴더가 최상위 경로에 생성되었습니다~

## 🏜 스크린샷
![image](https://github.com/user-attachments/assets/f864d2a2-ff01-4edb-8ed6-546e7d1e2d75)
![image](https://github.com/user-attachments/assets/e2c001c0-45d3-4da1-8f49-a992f9939dc3)

## 💬 To Reviewers
- useEffect 와 로컬 스토리지만 사용하면 새로고침해야 상태가 업데이트 되는 이슈가 있어서 zustand로 state를 빼고 로그인/로그아웃시 로컬 스토리지와 함께 초기값이 들어가게 했습니다
