### PR TITLE
[fix/레벨별 기록색깔 수정]

### DIFF
--- a/components/record/CalendarRecord.module.css
+++ b/components/record/CalendarRecord.module.css
@@ -23,12 +23,12 @@
   color: var(--main-color-3);
 }
 
-.record_box .subject_list.level2 li p {
+.record_box .subject_list.level2 li {
   background-color: #cdccff;
   color: #6153b8;
 }
 
-.record_box .subject_list.level3 li p {
+.record_box .subject_list.level3 li {
   background-color: var(--main-color-3);
   color: #f1f1ff;
 }

--- a/utils/levelUtils.ts
+++ b/utils/levelUtils.ts
@@ -1,8 +1,8 @@
 export const levelColor = (time: number): string => {
   const hours = Math.floor(time / 3600);
 
-  if (hours >= 3) return 'level3';
-  if (hours >= 2) return 'level2';
+  if (hours >= 6) return 'level3';
+  if (hours >= 3) return 'level2';
 
   return 'level1';
 };


### PR DESCRIPTION
## 📋 연관된 이슈 번호
- #56

## 📚 변경 사항
- 달력에서 레벨별 태그 배경색이 기묘하게 나오던 부분을 수정

## 🏜 스크린샷
- 수정전
![image](https://github.com/user-attachments/assets/f8ffc9fb-9056-408a-9a31-352a783c465d)
- 수정후
![image](https://github.com/user-attachments/assets/206048cd-9b93-446a-a07d-b6b52cca205e)

